### PR TITLE
[Course Scheduler] bugfix for calendar exports: Ignoring courses without meeting times

### DIFF
--- a/src/components/views/CourseScheduler/Timetable.jsx
+++ b/src/components/views/CourseScheduler/Timetable.jsx
@@ -155,6 +155,10 @@ const Timetable = ({
     const timeZone = "TZID=America/New_York:";
 
     for (const course of semAddedVisible) {
+      if (course.meetings === null) {
+        // this course hasn't set any meeting times, skipping it
+        continue;
+      }
       for (const meeting of course.meetings) {
         let result = "BEGIN:VEVENT\n";
         result += `SUMMARY:${courseString(course)}\n`;
@@ -247,6 +251,10 @@ const Timetable = ({
 
   const exportCalendar = () => {
     for (const course of semAddedVisible) {
+      if (course.meetings === null) {
+        // this course hasn't set any meeting times, skipping it
+        continue;
+      }
       for (const meeting of course.meetings) {
         exportCalendarEvent(course, meeting);
       }


### PR DESCRIPTION
## Bug Description

Exporting calendar fails and gives the `course.meetings is null` error if any of the selected courses haven't specified meeting time

Refer to this [Slack thread](https://purplecowsonline.slack.com/archives/C014ZH0BJCS/p1598489705002300) for details

![image](https://user-images.githubusercontent.com/49149993/91373554-31bae080-e806-11ea-9bcf-6b2043c0ff41.png)

## Bugfix

Ignoring courses without meeting times during calendar exports, so that the `course.meetings is null` error won't block calendar exports.

This patch applies to both .ICS export and Google Calendar export.