### PR TITLE
Fixed error in Facebook Edit

### DIFF
--- a/src/components/views/Facebook/FacebookEdit.jsx
+++ b/src/components/views/Facebook/FacebookEdit.jsx
@@ -33,7 +33,7 @@ const FacebookEdit = ({ currUser, navigateTo, updateUser, wso }) => {
       try {
         const userResponse = await wso.userService.getUser("me");
         const currTags = userResponse.data.tags;
-        updateTags(currTags.map((tag) => tag.name));
+        if (currTags) updateTags(currTags.map((tag) => tag.name));
       } catch (error) {
         updateErrors([error.message]);
       }


### PR DESCRIPTION
"When a user navigates to the Facebook Edit page, if their tag field is empty, an red error message appears above "Profile Picture" with the red text **\* Cannot read properties of undefined (reading 'map')**
Error is caused because "currTags" array is fetched from the API and a subsequent map function is called, however if the user has no tags, the program calls map on an empty array. A simple fix would be to run the map code only when the currTags array is defined."