### PR TITLE
Fixed off-cycle checkbox bug

### DIFF
--- a/src/components/views/Facebook/FacebookEdit.jsx
+++ b/src/components/views/Facebook/FacebookEdit.jsx
@@ -174,7 +174,7 @@ const FacebookEdit = ({ currUser, navigateTo, updateUser, wso }) => {
                 <strong>Off Cycle:&nbsp;</strong>
                 <input
                   type="checkbox"
-                  value={offCycle}
+                  checked={offCycle}
                   onChange={() => setOffCycle(!offCycle)}
                 />
                 (Checking this box will subtract 0.5 from your class year.)


### PR DESCRIPTION
"If a user edits their Facebook profile to indicate that they are off-cycle, upon clicking the "Edit" button, the off-cycle checkbox will not be checked. In order for the user to no longer be off-cycle, they must click the off-cycle checkbox again, which will return them to a normal class year."