### PR TITLE
fix: disable some eslint warnings in Goodrich

### DIFF
--- a/src/components/views/Goodrich/Manager/MenuTable.jsx
+++ b/src/components/views/Goodrich/Manager/MenuTable.jsx
@@ -1,3 +1,12 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable no-alert */
+/*
+TODO: Add prop validation (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md)
+TODO: remove the 3 alert statements (https://eslint.org/docs/rules/no-alert)
+
+The ESLint CI warnings are disabled for now.
+*/
+
 // React imports
 import React, { useState } from "react";
 import PropTypes from "prop-types";

--- a/src/components/views/Goodrich/Manager/PaidTable.jsx
+++ b/src/components/views/Goodrich/Manager/PaidTable.jsx
@@ -1,3 +1,10 @@
+/* eslint-disable react/prop-types */
+/*
+TODO: Add prop validation (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md)
+
+The ESLint CI warnings are disabled for now.
+*/
+
 // React imports
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";

--- a/src/components/views/Goodrich/Manager/PlacedTable.jsx
+++ b/src/components/views/Goodrich/Manager/PlacedTable.jsx
@@ -1,3 +1,12 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable no-alert */
+/*
+TODO: Add prop validation (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md)
+TODO: remove the 3 alert statements (https://eslint.org/docs/rules/no-alert)
+
+The ESLint CI warnings are disabled for now.
+*/
+
 // React imports
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";

--- a/src/components/views/Goodrich/Manager/ReadyTable.jsx
+++ b/src/components/views/Goodrich/Manager/ReadyTable.jsx
@@ -1,3 +1,12 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable no-alert */
+/*
+TODO: Add prop validation (https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md)
+TODO: remove the 3 alert statements (https://eslint.org/docs/rules/no-alert)
+
+The ESLint CI warnings are disabled for now.
+*/
+
 // React imports
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+/* Added to disable the ESLint CI warnings */
 // This optional code is used to register a service worker.
 // register() is not called by default.
 
@@ -11,9 +13,9 @@
 // opt-in, read https://bit.ly/CRA-PWA
 
 const isLocalhost = Boolean(
-  window.location.hostname === 'localhost' ||
+  window.location.hostname === "localhost" ||
     // [::1] is the IPv6 localhost address.
-    window.location.hostname === '[::1]' ||
+    window.location.hostname === "[::1]" ||
     // 127.0.0.1/8 is considered localhost for IPv4.
     window.location.hostname.match(
       /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
@@ -21,7 +23,7 @@ const isLocalhost = Boolean(
 );
 
 export function register(config) {
-  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+  if (process.env.NODE_ENV === "production" && "serviceWorker" in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
     if (publicUrl.origin !== window.location.origin) {
@@ -31,7 +33,7 @@ export function register(config) {
       return;
     }
 
-    window.addEventListener('load', () => {
+    window.addEventListener("load", () => {
       const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
 
       if (isLocalhost) {
@@ -42,8 +44,8 @@ export function register(config) {
         // service worker/PWA documentation.
         navigator.serviceWorker.ready.then(() => {
           console.log(
-            'This web app is being served cache-first by a service ' +
-              'worker. To learn more, visit https://bit.ly/CRA-PWA'
+            "This web app is being served cache-first by a service " +
+              "worker. To learn more, visit https://bit.ly/CRA-PWA"
           );
         });
       } else {
@@ -57,21 +59,21 @@ export function register(config) {
 function registerValidSW(swUrl, config) {
   navigator.serviceWorker
     .register(swUrl)
-    .then(registration => {
+    .then((registration) => {
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
         if (installingWorker == null) {
           return;
         }
         installingWorker.onstatechange = () => {
-          if (installingWorker.state === 'installed') {
+          if (installingWorker.state === "installed") {
             if (navigator.serviceWorker.controller) {
               // At this point, the updated precached content has been fetched,
               // but the previous service worker will still serve the older
               // content until all client tabs are closed.
               console.log(
-                'New content is available and will be used when all ' +
-                  'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
+                "New content is available and will be used when all " +
+                  "tabs for this page are closed. See https://bit.ly/CRA-PWA."
               );
 
               // Execute callback
@@ -82,7 +84,7 @@ function registerValidSW(swUrl, config) {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
+              console.log("Content is cached for offline use.");
 
               // Execute callback
               if (config && config.onSuccess) {
@@ -93,23 +95,23 @@ function registerValidSW(swUrl, config) {
         };
       };
     })
-    .catch(error => {
-      console.error('Error during service worker registration:', error);
+    .catch((error) => {
+      console.error("Error during service worker registration:", error);
     });
 }
 
 function checkValidServiceWorker(swUrl, config) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl)
-    .then(response => {
+    .then((response) => {
       // Ensure service worker exists, and that we really are getting a JS file.
-      const contentType = response.headers.get('content-type');
+      const contentType = response.headers.get("content-type");
       if (
         response.status === 404 ||
-        (contentType != null && contentType.indexOf('javascript') === -1)
+        (contentType != null && contentType.indexOf("javascript") === -1)
       ) {
         // No service worker found. Probably a different app. Reload the page.
-        navigator.serviceWorker.ready.then(registration => {
+        navigator.serviceWorker.ready.then((registration) => {
           registration.unregister().then(() => {
             window.location.reload();
           });
@@ -121,14 +123,14 @@ function checkValidServiceWorker(swUrl, config) {
     })
     .catch(() => {
       console.log(
-        'No internet connection found. App is running in offline mode.'
+        "No internet connection found. App is running in offline mode."
       );
     });
 }
 
 export function unregister() {
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.ready.then(registration => {
+  if ("serviceWorker" in navigator) {
+    navigator.serviceWorker.ready.then((registration) => {
       registration.unregister();
     });
   }


### PR DESCRIPTION
Disable some eslint warnings in Goodrich so CI won't fail due to ancient & unrelated errors.

Meanwhile, it's bad practice to write arrow functions in React. TODOs are added so we can (hopefully) revisit this at a later date