### PR TITLE
Round decimals from dormtrak rankings to nearest tenth

### DIFF
--- a/src/components/views/Dormtrak/DormtrakRanking.jsx
+++ b/src/components/views/Dormtrak/DormtrakRanking.jsx
@@ -13,7 +13,7 @@ import { Link } from "react-router5";
 const DormtrakRanking = ({ wso }) => {
   const [dormInfo, updateDormsInfo] = useState(null);
 
-  const roundToTenth = function(num) {
+  const roundToTenth = (num) => {
     return (+`${Math.round(`${num}e+1`)}e-1`).toFixed(1);
   };
 


### PR DESCRIPTION
This commit rounds the decimals given by the average satisfaction, location, loudness, and wifi to the nearest tenth before displaying them on the Dormtrak homepage.