### PR TITLE
resolved potentially non-unique keys

### DIFF
--- a/src/components/views/Dormtrak/DormtrakFacts.jsx
+++ b/src/components/views/Dormtrak/DormtrakFacts.jsx
@@ -88,7 +88,7 @@ const DormtrakFacts = ({ dorm, wso }) => {
         {ratingScores.map(
           (score, index) =>
             score !== 0 && (
-              <div key={score}>
+              <div key={ratingParameters[index]}>
                 {ratingParameters[index]}: {ratingScores[index].toPrecision(2)}
                 <br />
               </div>


### PR DESCRIPTION
If average ratings for the survey metrics are equal between two metrics, then the keys of the table elements will not be unique. To guarantee uniqueness, simply use the rating metric itself as the key.