### PR TITLE
More Dormtrak Rankings

### DIFF
--- a/src/components/views/Dormtrak/DormtrakRanking.jsx
+++ b/src/components/views/Dormtrak/DormtrakRanking.jsx
@@ -13,7 +13,7 @@ import { Link } from "react-router5";
 const DormtrakRanking = ({ wso }) => {
   const [dormInfo, updateDormsInfo] = useState(null);
 
-  const roundToTenth = function(num) {
+  const roundToTenth = (num) => {
     return (+`${Math.round(`${num}e+1`)}e-1`).toFixed(1);
   };
 


### PR DESCRIPTION
This merges PR #185 and #188 into the production branch. The purpose of this change is to add survey metric rankings to the Dormtrak homepage, in hopes of improving the relevance of the available rankings. The change has been tested on the development branch and appears to work well.