### PR TITLE
Removed Additional Prof API Refresh

### DIFF
--- a/src/components/views/Factrak/FactrakTopProfs.jsx
+++ b/src/components/views/Factrak/FactrakTopProfs.jsx
@@ -47,7 +47,6 @@ const FactrakTopProfs = ({ currUser, navigateTo, token, wso, route }) => {
       };
 
       if (route.params.aos) {
-        // updateAos(route.params.aos);
         params.areaOfStudyID = route.params.aos;
       }
 


### PR DESCRIPTION
The way the states were set up made the frontend call the profs API twice instead of only once per metric.