### PR TITLE
fix: Fix bug of ephmatch opt in

### DIFF
--- a/src/components/views/Ephmatch/EphmatchMain.jsx
+++ b/src/components/views/Ephmatch/EphmatchMain.jsx
@@ -87,12 +87,12 @@ const EphmatchMain = ({ token, wso }) => {
   }, [wso, location.pathname]);
 
   const EphmatchBody = () => {
-    // If token doesnt have access to matches, must mean they need to create a new account
-    if (!containsOneOfScopes(token, [scopes.ScopeEphmatchMatches])) {
-      return <EphmatchOptIn />;
-    }
-
     const Home = () => {
+      // If token doesnt have access to matches, must mean they need to create a new account
+      if (!containsOneOfScopes(token, [scopes.ScopeEphmatchMatches])) {
+        return <Navigate to="/ephmatch/opt-in" />;
+      }
+
       // If token doesnt have access to profiles, must mean that ephmatch is closed for the year
       //  || new Date() < ephmatchEndDate
       if (


### PR DESCRIPTION
Now we redirect user to separate route for opting in (instead of rendering it in place). Prior to the fix, when token is updated, the if clause causes the page to reload, thus rendering <EphmatchHome> Since we are updating tokens and api axios asynchronously, this leads us to load profiles prior to token change

Now if we redirect user to /opt-in, when they are done opt-in, they will be redirected back Hence, the program has the time to process token and api axios change