### PR TITLE
fix: Fix cannot edit bulletin bug

### DIFF
--- a/src/components/views/BulletinsDiscussions/BulletinForm.jsx
+++ b/src/components/views/BulletinsDiscussions/BulletinForm.jsx
@@ -57,10 +57,10 @@ const BulletinForm = ({ wso }) => {
           updateSource(bulletinData.source);
           updateDestination(bulletinData.destination);
           updateOffer(bulletinData.offer);
-          updateStartDate(bulletinData.date);
+          updateStartDate(new Date(bulletinData.date));
         } else {
           updateTitle(bulletinData.title);
-          updateStartDate(bulletinData.startDate);
+          updateStartDate(new Date(bulletinData.startDate));
         }
       } catch (error) {
         // We're only expecting 403 errors here


### PR DESCRIPTION
This is due to a type bug.
The bulletinData.date returned by our API is of type string, not type Date Then, during editing, startDate.getTime() fails since startDate is now a string Converting strings to Date types fix this


@WilliamsStudentsOnline/22board 
This is another reason to expedite our switch to typescript. If we have typescript, this bug could be catched by the typescript compiler.