### PR TITLE
I fixed the professor link in the factrak rankings

### DIFF
--- a/src/components/views/Factrak/FactrakTopProfs.jsx
+++ b/src/components/views/Factrak/FactrakTopProfs.jsx
@@ -103,7 +103,7 @@ const FactrakTopProfs = ({ currUser, token, wso }) => {
     return (
       <tr key={prof.id}>
         <td>
-          <Link to={`/factrak/professor/${prof.id}`}>{prof.name}</Link>
+          <Link to={`/factrak/professors/${prof.id}`}>{prof.name}</Link>
         </td>
         <td>{rating}</td>
         <td>


### PR DESCRIPTION
Previously the link said "professor" while the actual link required "professors".