### PR TITLE
Fix gcal bug because of typo

### DIFF
--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -32,7 +32,7 @@ export const DATES = {
   },
   Spring: {
     START: "20230201",
-    END: "20220512",
+    END: "20230512",
   },
   PREREG: {
     SPRING: "2022-10-30",


### PR DESCRIPTION
When adding class from wso schedule to gcal, it would only add one class instance instead of the whole semester because the end date was in 2022 when it should be 2023.  I think.