### PR TITLE
Hsa1/booktrak general cleanups

### DIFF
--- a/src/components/views/Booktrak/BooktrakHome.tsx
+++ b/src/components/views/Booktrak/BooktrakHome.tsx
@@ -21,28 +21,25 @@ const BooktrakHome = () => {
   const perPage = 20;
   const [total, updateTotal] = useState(0);
   const [isResultsLoading, updateResultLoadStatus] = useState(false);
-
-  const [selectedBook, updatedSelectedBook] = useState<ModelsBook | undefined>(
-    undefined
-  );
+  const urlQueryName = "book_query";
 
   useEffect(() => {
-    if (searchParams?.get("q")) {
-      updateQuery(searchParams.get("q") ?? "");
+    // update book query based on url query
+    if (searchParams?.get(urlQueryName)) {
+      updateQuery(searchParams.get(urlQueryName) ?? "");
     } else {
       updateQuery("");
     }
   }, [searchParams]);
 
   const loadBooks = async () => {
-    if (!searchParams?.get("q")) {
+    if (!searchParams?.get(urlQueryName)) {
       updateResults([]);
       updateTotal(0);
       return;
     }
-    updatedSelectedBook(undefined);
     const queryParams = {
-      q: searchParams.get("q") ?? undefined,
+      q: searchParams.get(urlQueryName) ?? undefined,
       limit: perPage,
     };
     try {
@@ -58,13 +55,13 @@ const BooktrakHome = () => {
   };
 
   useEffect(() => {
-    if (searchParams?.get("q")) {
+    if (searchParams?.get(urlQueryName)) {
       updateResultLoadStatus(true);
     }
     updateTotal(0);
     loadBooks();
     // eslint-disable-next-line
-  }, [wso, searchParams?.get("q")]);
+  }, [wso, searchParams?.get(urlQueryName)]);
 
   // Displays results in a list view when there are too many results
   const ListView = () => {
@@ -185,7 +182,7 @@ const BooktrakHome = () => {
       );
     }
 
-    if (total === 0 && searchParams?.get("q"))
+    if (total === 0 && searchParams?.get(urlQueryName))
       return (
         <>
           <br />
@@ -198,7 +195,7 @@ const BooktrakHome = () => {
 
   const submitHandler: React.FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
-    searchParams.set("q", query);
+    searchParams.set(urlQueryName, query);
     navigateTo(`/booktrak?${searchParams.toString()}`);
   };
 
@@ -221,7 +218,7 @@ const BooktrakHome = () => {
           className="submit"
         />
       </form>
-      {searchParams?.get("q") &&
+      {searchParams?.get(urlQueryName) &&
         (results ? (
           <article className="facebook-results">
             <section>{BooktrakResults()}</section>

--- a/src/components/views/Booktrak/BooktrakHome.tsx
+++ b/src/components/views/Booktrak/BooktrakHome.tsx
@@ -18,49 +18,46 @@ const BooktrakHome = () => {
   const [query, updateQuery] = useState("");
 
   const [results, updateResults] = useState<ModelsBook[]>([]);
-  const perPage = 20;
+  const resultsPerPage = 20;
   const [total, updateTotal] = useState(0);
-  const [isResultsLoading, updateResultLoadStatus] = useState(false);
+  const [isResultsLoading, updateIsResultsLoading] = useState(false);
   const urlQueryName = "book_query";
 
-  useEffect(() => {
-    // update book query based on url query
-    if (searchParams?.get(urlQueryName)) {
-      updateQuery(searchParams.get(urlQueryName) ?? "");
-    } else {
-      updateQuery("");
-    }
-  }, [searchParams]);
-
   const loadBooks = async () => {
-    if (!searchParams?.get(urlQueryName)) {
+    const bookQuery = searchParams?.get(urlQueryName);
+    if (!bookQuery) {
       updateResults([]);
       updateTotal(0);
       return;
     }
+
     const queryParams = {
-      q: searchParams.get(urlQueryName) ?? undefined,
-      limit: perPage,
+      q: bookQuery,
+      limit: resultsPerPage,
     };
+
     try {
       const resultsResponse = await wso.booktrakService.searchBooks(
         queryParams
       );
       updateResults(resultsResponse.data ?? []);
       updateTotal(resultsResponse.data?.length ?? 0);
-      updateResultLoadStatus(false);
+      updateIsResultsLoading(false);
     } catch {
       updateResults([]);
+      updateTotal(0);
     }
   };
 
   useEffect(() => {
     if (searchParams?.get(urlQueryName)) {
-      updateResultLoadStatus(true);
+      updateQuery(searchParams.get(urlQueryName) ?? "");
+      updateIsResultsLoading(true);
+    } else {
+      updateQuery("");
     }
-    updateTotal(0);
+
     loadBooks();
-    // eslint-disable-next-line
   }, [wso, searchParams?.get(urlQueryName)]);
 
   // Displays results in a list view when there are too many results

--- a/src/components/views/Booktrak/BooktrakLayout.tsx
+++ b/src/components/views/Booktrak/BooktrakLayout.tsx
@@ -28,9 +28,6 @@ const BooktrakLayout = ({ children }: { children: React.ReactElement }) => {
             <li>
               <Link to="/booktrak/sell">Sell Listings</Link>
             </li>
-            <li>
-              <Link to="/booktrak/create">Create Listings</Link>
-            </li>
             {currUser === null
               ? null
               : [


### PR DESCRIPTION
General cleanups to booktrak. These don't actually change the page, except for the removal of the 'create listing tab' (this was removed because the buy/sell buttons on any given book accomplish the purpose of this tab).

Demo:

https://github.com/WilliamsStudentsOnline/wso-react/assets/65182701/7648a794-9550-4ade-b969-c8aae8971bab