### PR TITLE
fixed pagination selection bug

### DIFF
--- a/src/components/PaginationButtons.jsx
+++ b/src/components/PaginationButtons.jsx
@@ -29,7 +29,7 @@ const PaginationButtons = ({
           Page&nbsp;&nbsp;&nbsp;
           <Select
             onChange={(event) => {
-              selectionHandler(parseInt(event.target.value, 10));
+              selectionHandler(parseInt(event.target.value - 1, 10));
             }}
             options={Array.from(
               Array(Math.ceil(total / perPage)),


### PR DESCRIPTION
While working on booktrak, I ran into a bug with the page selector in the pagination component. When you select a page, the selector actually goes to that page + 1. A video of the bug, and the fix in action, is included in this PR.

Bug:
https://github.com/WilliamsStudentsOnline/wso-react/assets/65182701/6e8fc933-d184-447d-9e8c-b66daf608690

Fix Demo:
https://github.com/WilliamsStudentsOnline/wso-react/assets/65182701/34112051-196c-4a50-b12d-db4d447f4fc0