### PR TITLE
updated page navigation link styling

### DIFF
--- a/src/components/stylesheets/Booktrak.css
+++ b/src/components/stylesheets/Booktrak.css
@@ -4,6 +4,12 @@
   margin-right: auto;
 }
 
+.booktrak-active-link {
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 2px;
+}
+
 .booktrak-search-form {
   margin-left: 8.5298042998%;
   width: 82.5%;

--- a/src/components/views/Booktrak/BooktrakLayout.tsx
+++ b/src/components/views/Booktrak/BooktrakLayout.tsx
@@ -6,33 +6,51 @@ import { useAppSelector } from "../../../lib/store";
 import { getCurrUser } from "../../../lib/authSlice";
 
 // Additional imports
-import { Link } from "react-router-dom";
+import { NavLink } from "react-router-dom";
+import "../../stylesheets/Booktrak.css";
 
 const BooktrakLayout = ({ children }: { children: React.ReactElement }) => {
   const currUser = useAppSelector(getCurrUser);
+
+  const applyActiveLinkStyling = ({
+    isActive,
+  }: {
+    isActive: boolean;
+  }): string => (isActive ? "booktrak-active-link" : "");
 
   return (
     <div className="facebook">
       <header>
         <div className="page-head">
           <h1>
-            <Link to="/booktrak">Booktrak</Link>
+            <NavLink to="/booktrak">Booktrak</NavLink>
           </h1>
           <ul>
             <li>
-              <Link to="/booktrak">Search Books</Link>
+              <NavLink to="/booktrak" className={applyActiveLinkStyling} end>
+                Search Books
+              </NavLink>
             </li>
             <li>
-              <Link to="/booktrak/buy">Buy Listings</Link>
+              <NavLink to="/booktrak/buy" className={applyActiveLinkStyling}>
+                Buy Listings
+              </NavLink>
             </li>
             <li>
-              <Link to="/booktrak/sell">Sell Listings</Link>
+              <NavLink to="/booktrak/sell" className={applyActiveLinkStyling}>
+                Sell Listings
+              </NavLink>
             </li>
             {currUser === null
               ? null
               : [
                   <li key="edit">
-                    <Link to="/booktrak/edit"> My Listings </Link>
+                    <NavLink
+                      to="/booktrak/edit"
+                      className={applyActiveLinkStyling}
+                    >
+                      My Listings
+                    </NavLink>
                   </li>,
                 ]}
           </ul>


### PR DESCRIPTION
I wanted to make it clear which page the user is on when they're navigating within the booktrak site, so I added an underline to the active page's link.

Demo:
https://github.com/WilliamsStudentsOnline/wso-react/assets/65182701/9b58aaa3-e008-4a44-8f68-ec6ac3dc9ba3