### PR TITLE
updated how booktrak frontend interfaces with new API

### DIFF
--- a/src/components/views/Booktrak/BooktrakBook.tsx
+++ b/src/components/views/Booktrak/BooktrakBook.tsx
@@ -29,18 +29,15 @@ const BooktrakBook = () => {
     const loadTarget = async () => {
       // Check if current book is in DB
       if (viewBook) {
-        const isbn = viewBook.isbn13 ?? viewBook.isbn10 ?? null;
-        console.log(viewBook);
+        const isbn = viewBook.isbn13 ?? null;
         if (!isbn) {
           return;
         }
         try {
           const bookResponse = await wso.booktrakService.listBooks({
-            isbn_10: isbn.length === 10 ? isbn : undefined,
-            isbn_13: isbn.length === 13 ? isbn : undefined,
+            isbn: isbn,
           });
           const books = bookResponse.data;
-          console.log(books);
           if (books) {
             navigateTo(`/booktrak/books/${books[0].id}`);
             updateViewBook(books[0]);
@@ -120,20 +117,13 @@ const BooktrakBook = () => {
 
     return (
       <>
-        {book.isbn10 ? (
-          <>
-            <h5>ISBN-10:</h5>
-            <h4>{book.isbn10}</h4>
-            <br />
-          </>
-        ) : null}
-        {book?.isbn13 ? (
+        {book?.isbn13 && (
           <>
             <h5>ISBN-13:</h5>
             <h4>{book.isbn13}</h4>
             <br />
           </>
-        ) : null}{" "}
+        )}
       </>
     );
   };

--- a/src/components/views/Booktrak/BooktrakListings.tsx
+++ b/src/components/views/Booktrak/BooktrakListings.tsx
@@ -9,10 +9,9 @@ import { Link, useNavigate } from "react-router-dom";
 // Additional Imports
 import {
   ModelsBook,
-  ModelsBookCondition,
   ModelsBookListing,
 } from "wso-api-client/lib/services/types";
-import { pascalToTitleCase } from "../../../lib/general";
+import { BookConditionEnumToString } from "./BooktrakUtils";
 
 const BooktrakListings = ({ book }: { book: ModelsBook }) => {
   const wso = useAppSelector(getWSO);
@@ -26,14 +25,15 @@ const BooktrakListings = ({ book }: { book: ModelsBook }) => {
         return;
       }
       try {
+        const ListingTypeEnum = ModelsBookListing.ListingTypeEnum;
         const buyListingsResponse = await wso.booktrakService.listBookListings({
           bookID: book.id,
-          isBuyListing: true,
+          listingType: ListingTypeEnum.BUY,
         });
         const sellListingsResponse = await wso.booktrakService.listBookListings(
           {
             bookID: book.id,
-            isBuyListing: false,
+            listingType: ListingTypeEnum.SELL,
           }
         );
         updateBuyListings(buyListingsResponse.data ?? []);
@@ -66,11 +66,7 @@ const BooktrakListings = ({ book }: { book: ModelsBook }) => {
                       {listing.user?.name}
                     </Link>
                   </td>
-                  <td>
-                    {pascalToTitleCase(
-                      ModelsBookCondition[listing.condition ?? 0]
-                    )}
-                  </td>
+                  <td>{BookConditionEnumToString(listing.condition ?? 0)}</td>
                   <td>{listing.description}</td>
                 </tr>
               );

--- a/src/components/views/Booktrak/BooktrakResultsListView.tsx
+++ b/src/components/views/Booktrak/BooktrakResultsListView.tsx
@@ -32,7 +32,7 @@ const BooktrakResultsListView = ({
                 </Link>
               </td>
               <td>{book.authors?.join(", ")}</td>
-              <td>{book.isbn13 ?? book.isbn10}</td>
+              <td>{book.isbn13}</td>
               <td style={{ textAlign: "center" }}>
                 <a href={book.infoLink}>
                   {book.imageLink ? (

--- a/src/components/views/Booktrak/BooktrakUtils.tsx
+++ b/src/components/views/Booktrak/BooktrakUtils.tsx
@@ -1,0 +1,49 @@
+import { ModelsBookListing } from "wso-api-client/lib/services/types";
+
+export const BookConditionEnumToString = (
+  condition: ModelsBookListing.ConditionEnum
+): string => {
+  const ListingConditionEnum = ModelsBookListing.ConditionEnum;
+  switch (condition) {
+    case ListingConditionEnum.Empty:
+      return "";
+    case ListingConditionEnum.POOR:
+      return "Poor";
+    case ListingConditionEnum.FAIR:
+      return "Fair";
+    case ListingConditionEnum.GOOD:
+      return "Good";
+    case ListingConditionEnum.VERYGOOD:
+      return "Very Good";
+    case ListingConditionEnum.LIKENEW:
+      return "Like New";
+    case ListingConditionEnum.NEW:
+      return "New";
+    default:
+      return "";
+  }
+};
+
+export const BookConditionStringToEnum = (
+  condition: string
+): ModelsBookListing.ConditionEnum => {
+  const ListingConditionEnum = ModelsBookListing.ConditionEnum;
+  switch (condition) {
+    case "":
+      return ListingConditionEnum.Empty;
+    case "Poor":
+      return ListingConditionEnum.POOR;
+    case "Fair":
+      return ListingConditionEnum.FAIR;
+    case "Good":
+      return ListingConditionEnum.GOOD;
+    case "Very Good":
+      return ListingConditionEnum.VERYGOOD;
+    case "Like New":
+      return ListingConditionEnum.LIKENEW;
+    case "New":
+      return ListingConditionEnum.NEW;
+    default:
+      return ListingConditionEnum.Empty;
+  }
+};


### PR DESCRIPTION
@AndrewMuh updated the booktrak API to work with the new backend. This change meant that the frontend needed to be updated to correctly interact with the new API. 
Note: The reason the two functions in  src/components/views/Booktrak/BooktrakUtils.tsx are necessary (instead of more generalizable functions) is that, for some reason, typescript creates a two way mapping for both of the enums mentioned in that file. Because of this, it's impossible to tell the difference between the keys and values of these enums without doing some manual work.

Demo:
https://github.com/WilliamsStudentsOnline/wso-react/assets/65182701/347292c0-1c90-44e4-b638-a54feb865801