### PR TITLE
added tooltips for buy/sell pages, updated condition filtering tooltips

### DIFF
--- a/src/components/stylesheets/Booktrak.css
+++ b/src/components/stylesheets/Booktrak.css
@@ -46,6 +46,11 @@
   margin-right: auto;
   padding-bottom: 10px;
   max-width: 57em;
+
+  .title-container {
+    display: flex;
+    align-items: center;
+  }
 }
 
 .booktrak-listings-dual-display-container {

--- a/src/components/views/Booktrak/BooktrakListings.tsx
+++ b/src/components/views/Booktrak/BooktrakListings.tsx
@@ -167,13 +167,20 @@ const BooktrakListings = ({
   // buy/sell/my listings page
   return (
     <div className="booktrak-listings-page-container">
-      <h3>
-        {showMyListings
-          ? "My Listings"
-          : showBuyListings
-          ? "Buy Listings"
-          : "Sell Listings"}
-      </h3>
+      {showMyListings ? (
+        <h3>My Listings</h3>
+      ) : (
+        <div className="title-container">
+          <h3>{showBuyListings ? "Buy Listings" : "Sell Listings"}</h3>
+          <Tooltip
+            message={`This page shows posts from people who want to ${
+              showBuyListings ? "buy" : "sell"
+            } a book. Reach out if you see a listing that matches a book that you want to ${
+              showBuyListings ? "sell" : "buy"
+            }`}
+          />
+        </div>
+      )}
       {!showMyListings && (
         <div>
           <BooktrakCourseSearch
@@ -186,7 +193,13 @@ const BooktrakListings = ({
             <div className="inner-container">
               <h3>
                 Minimum Condition
-                <Tooltip message="The worst book condition that you would still consider buying" />
+                <Tooltip
+                  message={`The worst book condition that you ${
+                    showBuyListings
+                      ? "could sell"
+                      : "would still consider buying"
+                  }`}
+                />
               </h3>
               <BooktrakConditionSelection
                 condition={minCondition}
@@ -196,7 +209,13 @@ const BooktrakListings = ({
             <div className="inner-container">
               <h3>
                 Maximum Condition
-                <Tooltip message="The best book condition that you would still consider buying (books with worse conditions may be less expensive)" />
+                <Tooltip
+                  message={`The best book condition that you ${
+                    showBuyListings
+                      ? "could sell"
+                      : "would still consider buying"
+                  } (books with worse conditions may be less expensive)`}
+                />
               </h3>
               <BooktrakConditionSelection
                 condition={maxCondition}


### PR DESCRIPTION
I realized that the buy/sell pages might be a little confusing at first (specifically that, if you're looking at the buy page, you should be looking to sell your book to someone who posted a listing, and the opposite for the sell page). I added some tooltips to explain the pages a little better, and also fixed the tooltips for the conditions to work for both the buy/sell page)

Demo:
https://github.com/WilliamsStudentsOnline/wso-react/assets/65182701/d6394b80-0a05-4b49-aee1-83d78400c7dc