### PR TITLE
added column for existing buy/sell listings

### DIFF
--- a/src/components/stylesheets/Booktrak.css
+++ b/src/components/stylesheets/Booktrak.css
@@ -23,10 +23,6 @@
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
 }
 
-.create-listing-button {
-  margin-left: auto;
-}
-
 .book-missing-image {
   display: inline-block;
   cursor: pointer;

--- a/src/components/stylesheets/Booktrak.css
+++ b/src/components/stylesheets/Booktrak.css
@@ -23,6 +23,10 @@
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
 }
 
+.create-listing-button {
+  margin-left: auto;
+}
+
 .book-missing-image {
   display: inline-block;
   cursor: pointer;

--- a/src/components/views/Booktrak/BooktrakBookSearchResults.tsx
+++ b/src/components/views/Booktrak/BooktrakBookSearchResults.tsx
@@ -1,16 +1,29 @@
 import React from "react";
 import { Link, NavigateFunction } from "react-router-dom";
-import { ModelsBook } from "wso-api-client/lib/services/types";
+import {
+  ModelsBook,
+  ModelsBookListing,
+} from "wso-api-client/lib/services/types";
 import Button from "../../Components";
 import "../../stylesheets/Booktrak.css";
 
 const BooktrakBookSearchResults = ({
   results,
+  listingResults,
   navigateTo,
 }: {
   results: ModelsBook[];
+  listingResults: (ModelsBookListing[] | undefined)[];
   navigateTo: NavigateFunction;
 }) => {
+  const filterListings = (
+    listings: ModelsBookListing[] | undefined,
+    listingType: ModelsBookListing.ListingTypeEnum
+  ) => {
+    if (!listings || listings.length === 0) return [];
+    return listings.filter((listing) => listing.listingType === listingType);
+  };
+
   return (
     <table>
       <thead>
@@ -19,7 +32,8 @@ const BooktrakBookSearchResults = ({
           <th>Authors</th>
           <th className="unix-column">ISBN</th>
           <th>Cover</th>
-          <th>Buy/Sell</th>
+          <th>Buy/Sell Listings</th>
+          <th>Create Buy/Sell Listing</th>
         </tr>
       </thead>
       <tbody>
@@ -62,6 +76,29 @@ const BooktrakBookSearchResults = ({
                   </a>
                 </td>
                 <td>
+                  {(listingResults[i]?.length ?? 0) > 0 ? (
+                    <Link to={"/booktrak/books"} state={{ book }}>
+                      Browse{" "}
+                      {
+                        filterListings(
+                          listingResults[i],
+                          ModelsBookListing.ListingTypeEnum.BUY
+                        ).length
+                      }{" "}
+                      buy listings and{" "}
+                      {
+                        filterListings(
+                          listingResults[i],
+                          ModelsBookListing.ListingTypeEnum.SELL
+                        ).length
+                      }{" "}
+                      sell listings
+                    </Link>
+                  ) : (
+                    "This book currently has no listings"
+                  )}
+                </td>
+                <td>
                   <Button
                     onClick={() =>
                       navigateTo(`/booktrak/listings/create`, {
@@ -70,10 +107,10 @@ const BooktrakBookSearchResults = ({
                         },
                       })
                     }
-                    className="inline-button"
+                    className="inline-button create-listing-button"
                   >
                     Buy
-                  </Button>{" "}
+                  </Button>
                   <Button
                     onClick={() =>
                       navigateTo(`/booktrak/listings/create`, {
@@ -82,10 +119,10 @@ const BooktrakBookSearchResults = ({
                         },
                       })
                     }
-                    className="inline-button"
+                    className="inline-button create-listing-button"
                   >
                     Sell
-                  </Button>{" "}
+                  </Button>
                 </td>
               </tr>
             ))}

--- a/src/components/views/Booktrak/BooktrakBookSearchResults.tsx
+++ b/src/components/views/Booktrak/BooktrakBookSearchResults.tsx
@@ -23,13 +23,18 @@ const BooktrakBookSearchResults = ({
     if (!listings || listings.length === 0) return [];
     return listings.filter((listing) => listing.listingType === listingType);
   };
+  const buyListings = listingResults.map((listing) =>
+    filterListings(listing, ModelsBookListing.ListingTypeEnum.BUY)
+  );
+  const sellListings = listingResults.map((listing) =>
+    filterListings(listing, ModelsBookListing.ListingTypeEnum.SELL)
+  );
 
   return (
     <table>
       <thead>
         <tr>
           <th>Title</th>
-          <th>Authors</th>
           <th className="unix-column">ISBN</th>
           <th>Cover</th>
           <th>Buy/Sell Listings</th>
@@ -46,8 +51,9 @@ const BooktrakBookSearchResults = ({
                   <Link to={"/booktrak/books"} state={{ book }}>
                     {book.title}
                   </Link>
+                  <br />
+                  by {book.authors?.join(", ")}
                 </td>
-                <td>{book.authors?.join(", ")}</td>
                 <td>{book.isbn13}</td>
                 <td style={{ textAlign: "center" }}>
                   <a href={book.infoLink}>
@@ -78,21 +84,16 @@ const BooktrakBookSearchResults = ({
                 <td>
                   {(listingResults[i]?.length ?? 0) > 0 ? (
                     <Link to={"/booktrak/books"} state={{ book }}>
-                      Browse{" "}
-                      {
-                        filterListings(
-                          listingResults[i],
-                          ModelsBookListing.ListingTypeEnum.BUY
-                        ).length
-                      }{" "}
-                      buy listings and{" "}
-                      {
-                        filterListings(
-                          listingResults[i],
-                          ModelsBookListing.ListingTypeEnum.SELL
-                        ).length
-                      }{" "}
-                      sell listings
+                      {buyListings[i].length}{" "}
+                      {buyListings[i].length === 1 ? "person is" : "people are"}{" "}
+                      offering to buy this book
+                      <br />
+                      <br />
+                      {sellListings[i].length}{" "}
+                      {sellListings[i].length === 1
+                        ? "person is"
+                        : "people are"}{" "}
+                      offering to sell this book
                     </Link>
                   ) : (
                     "This book currently has no listings"
@@ -107,7 +108,7 @@ const BooktrakBookSearchResults = ({
                         },
                       })
                     }
-                    className="inline-button create-listing-button"
+                    className="inline-button"
                   >
                     Buy
                   </Button>

--- a/src/components/views/Booktrak/BooktrakBookSearchResults.tsx
+++ b/src/components/views/Booktrak/BooktrakBookSearchResults.tsx
@@ -37,8 +37,8 @@ const BooktrakBookSearchResults = ({
           <th>Title</th>
           <th className="unix-column">ISBN</th>
           <th>Cover</th>
-          <th>Buy/Sell Listings</th>
-          <th>Create Buy/Sell Listing</th>
+          <th>Listings</th>
+          <th>Create Listing</th>
         </tr>
       </thead>
       <tbody>

--- a/src/components/views/Booktrak/BooktrakListings.tsx
+++ b/src/components/views/Booktrak/BooktrakListings.tsx
@@ -16,10 +16,6 @@ import PaginationButtons from "../../PaginationButtons";
 import BooktrakListingsTable from "./BooktrakListingsTable";
 import "../../stylesheets/Booktrak.css";
 import BooktrakCourseSearch from "./BooktrakCourseSearch";
-import {
-  BookConditionEnumToString,
-  BookConditionStringToEnum,
-} from "./BooktrakUtils";
 import Tooltip from "../../Tooltip";
 import BooktrakConditionSelection from "./BooktrakConditionSelection";
 


### PR DESCRIPTION
I realized that there was not an intuitive way to search for a specific book and find out if it had any buy or sell listings, so I added a column to the search page for existing buy/sell listings. This was accompanied by some backend fixes (https://github.com/WilliamsStudentsOnline/wso-go/pull/199)

Demo:
https://github.com/WilliamsStudentsOnline/wso-react/assets/65182701/e9cfb785-f6d0-4786-87d7-354199e4b665