### PR TITLE
Upgrade API

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "serialize-javascript": "3.1.0",
     "timeago.js": "^4.0.0-beta.2",
     "typeface-source-sans-pro": "^0.0.75",
-    "wso-api-client": "24.02.19"
+    "wso-api-client": "^24.11.10"
   },
   "devDependencies": {
     "@types/jest": "^27.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11298,10 +11298,10 @@ ws@^8.4.2:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
   integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==
 
-wso-api-client@24.02.19:
-  version "24.2.19"
-  resolved "https://registry.yarnpkg.com/wso-api-client/-/wso-api-client-24.2.19.tgz#b1ed94c13b4eaf579a9613235c4589ad9041aff2"
-  integrity sha512-h/6FeNeH5JSE7Qeh+RQE89NPb835ZxC/A/wwFqq0VUgO23S7k/p4/law4vsGD8lRVx2KCIW6+W3r8K3FwYlfSQ==
+wso-api-client@^24.11.10:
+  version "24.11.10"
+  resolved "https://registry.yarnpkg.com/wso-api-client/-/wso-api-client-24.11.10.tgz#c009ec01b8fe835c475ff9e0519528e60a8b5cb3"
+  integrity sha512-Hov/d7z/5+tsXshJ4FRgkutNaO+nrivcNi94AAzA70xH6cjMuHd0dgopVIw/HEr0ZaRGNZj3JdJewsrM093zYA==
   dependencies:
     axios "^0.26.1"
     jwt-decode "^3.1.2"


### PR DESCRIPTION
@mlaws21 trying to replace `localStorage.getItem` and `localStorage.setItem` calls with wrappers to the API calls (`wso.courseSchedulerService.setSelection()` etc.) but I don't know if it is possible to refactor this without moving stuff to React hooks/components (and don't know the proper way to do so)